### PR TITLE
Change generated APK app name

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,6 +14,7 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
+        setProperty("archivesBaseName", "cuadramo")
     }
     buildTypes {
         release {


### PR DESCRIPTION
This will change the APK file name from `app-debug.apk` to `cuadramo-debug.apk` to make it easier for anyone to identify which app it belongs to by using the `archivesBaseName` property in the `app/build.gradle`.