### PR TITLE
Fix FAB overlapping last catalog item

### DIFF
--- a/app/src/main/res/layout/activity_catalog.xml
+++ b/app/src/main/res/layout/activity_catalog.xml
@@ -19,6 +19,8 @@
         android:id="@+id/catalogRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:paddingBottom="84dp"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton


### PR DESCRIPTION
This issue would prevent the user to be able to see the full content
of the last item inside the Catalog's RecyclerView.