### PR TITLE
Fix: app closing after signing out

### DIFF
--- a/app/src/main/java/com/chrisvasqm/cuadramo/catalog/CatalogActivity.kt
+++ b/app/src/main/java/com/chrisvasqm/cuadramo/catalog/CatalogActivity.kt
@@ -21,6 +21,7 @@ import kotlinx.android.synthetic.main.activity_catalog.*
 import kotlinx.android.synthetic.main.toolbar.*
 
 class CatalogActivity : AppCompatActivity(), CatalogContract.View {
+
     private lateinit var auth: FirebaseAuth
 
     private lateinit var client: GoogleSignInClient
@@ -103,7 +104,7 @@ class CatalogActivity : AppCompatActivity(), CatalogContract.View {
         setPositiveButton(R.string.sign_out) { _: DialogInterface, _: Int ->
             client.signOut().addOnCompleteListener {
                 auth.signOut()
-                finish()
+                goToSignInScreen()
             }
         }
         setNegativeButton(android.R.string.cancel) { _: DialogInterface, _: Int -> }
@@ -116,5 +117,10 @@ class CatalogActivity : AppCompatActivity(), CatalogContract.View {
     override fun goToAboutScreen() {
         router.goToAboutScreen()
     }
+
+    override fun goToSignInScreen() {
+        router.goToSignInScreen()
+    }
+
 
 }

--- a/app/src/main/java/com/chrisvasqm/cuadramo/catalog/CatalogContract.kt
+++ b/app/src/main/java/com/chrisvasqm/cuadramo/catalog/CatalogContract.kt
@@ -15,6 +15,8 @@ interface CatalogContract {
 
         fun goToAboutScreen()
 
+        fun goToSignInScreen()
+
     }
 
     interface Presenter : BasePresenter<View> {
@@ -36,6 +38,8 @@ interface CatalogContract {
         fun goToPlayStore()
 
         fun goToAboutScreen()
+
+        fun goToSignInScreen()
 
     }
 

--- a/app/src/main/java/com/chrisvasqm/cuadramo/catalog/CatalogRouter.kt
+++ b/app/src/main/java/com/chrisvasqm/cuadramo/catalog/CatalogRouter.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.net.Uri
 import com.chrisvasqm.cuadramo.about.AboutActivity
 import com.chrisvasqm.cuadramo.editor.EditorActivity
+import com.chrisvasqm.cuadramo.signin.SignInActivity
 
 class CatalogRouter(private val activity: CatalogActivity) : CatalogContract.Router {
 
@@ -20,6 +21,12 @@ class CatalogRouter(private val activity: CatalogActivity) : CatalogContract.Rou
 
     override fun goToAboutScreen() {
         Intent(activity, AboutActivity::class.java).also { activity.startActivity(it) }
+    }
+
+    override fun goToSignInScreen() {
+        Intent(activity, SignInActivity::class.java)
+                .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                .also { activity.startActivity(it) }
     }
 
 }


### PR DESCRIPTION
## Current behaviour

When the user signs out, the app closes.'

## Expected behaviour

When the user signs out, he/she should be taken back to the Sign In screen, and not should not be able to go back to the Catalog screen if he/she presses the Back button, instead, the app should close.