### PR TITLE
Fix: Replace synthetic with View Binding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,9 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {

--- a/app/src/main/java/com/chrisvasqm/cuadramo/about/AboutActivity.kt
+++ b/app/src/main/java/com/chrisvasqm/cuadramo/about/AboutActivity.kt
@@ -2,28 +2,29 @@ package com.chrisvasqm.cuadramo.about
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import com.chrisvasqm.cuadramo.R
-import kotlinx.android.synthetic.main.activity_about.*
+import com.chrisvasqm.cuadramo.databinding.ActivityAboutBinding
 import kotlinx.android.synthetic.main.toolbar.*
 
 class AboutActivity : AppCompatActivity(), AboutContract.View {
+
+    private lateinit var binding: ActivityAboutBinding
 
     private lateinit var router: AboutContract.Router
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_about)
+        binding = ActivityAboutBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         setSupportActionBar(toolbar)
-        displayVersionNumber()
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
+        displayVersionNumber()
+
+        binding.linearGitHubLink.setOnClickListener { goToGitHub() }
+        binding.linearChristianLink.setOnClickListener { goToChristianLink() }
+        binding.linearCarlaLink.setOnClickListener { goToCristalLink() }
+
         router = AboutRouter(this)
-
-        linearGitHubLink.setOnClickListener { goToGitHub() }
-
-        linearChristianLink.setOnClickListener { goToChristianLink() }
-
-        linearCarlaLink.setOnClickListener { goToCristalLink() }
     }
 
     override fun goToGitHub() {
@@ -40,6 +41,6 @@ class AboutActivity : AppCompatActivity(), AboutContract.View {
 
     private fun displayVersionNumber() {
         val packageInfo = this.packageManager.getPackageInfo(packageName, 0)
-        textVersionNumber.text = "v${packageInfo.versionName}"
+        binding.textVersionNumber.text = "v${packageInfo.versionName}"
     }
 }

--- a/app/src/main/java/com/chrisvasqm/cuadramo/catalog/CatalogActivity.kt
+++ b/app/src/main/java/com/chrisvasqm/cuadramo/catalog/CatalogActivity.kt
@@ -11,16 +11,18 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.chrisvasqm.cuadramo.R
 import com.chrisvasqm.cuadramo.data.models.Cuadre
+import com.chrisvasqm.cuadramo.databinding.ActivityCatalogBinding
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.FirebaseDatabase
-import kotlinx.android.synthetic.main.activity_catalog.*
 import kotlinx.android.synthetic.main.toolbar.*
 
 class CatalogActivity : AppCompatActivity(), CatalogContract.View {
+
+    private lateinit var binding: ActivityCatalogBinding
 
     private lateinit var auth: FirebaseAuth
 
@@ -36,11 +38,12 @@ class CatalogActivity : AppCompatActivity(), CatalogContract.View {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_catalog)
+        binding = ActivityCatalogBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         setSupportActionBar(toolbar)
+
         presenter = CatalogPresenter().apply { attach(this@CatalogActivity) }
         presenter.loadCatalog()
-        router = CatalogRouter(this)
 
         firebaseDatabase = FirebaseDatabase.getInstance()
         databaseReference = firebaseDatabase.reference
@@ -48,13 +51,14 @@ class CatalogActivity : AppCompatActivity(), CatalogContract.View {
         auth = FirebaseAuth.getInstance()
 
         val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-                .requestIdToken(getString(R.string.default_web_client_id))
-                .requestEmail()
-                .build()
+            .requestIdToken(getString(R.string.default_web_client_id))
+            .requestEmail()
+            .build()
 
         client = GoogleSignIn.getClient(this, gso)
 
-        fabAdd.setOnClickListener {
+        router = CatalogRouter(this)
+        binding.fabAdd.setOnClickListener {
             router.goToEditorScreen()
         }
     }
@@ -84,11 +88,16 @@ class CatalogActivity : AppCompatActivity(), CatalogContract.View {
 
     private fun setupRecyclerView(cuadres: MutableList<Cuadre>) {
         val animation = AnimationUtils.loadLayoutAnimation(this, R.anim.layout_animation_fall_down)
-        catalogRecyclerView.apply {
+        binding.catalogRecyclerView.apply {
             setHasFixedSize(true)
             adapter = CatalogAdapter(cuadres, supportFragmentManager)
             layoutManager = LinearLayoutManager(this@CatalogActivity)
-            addItemDecoration(DividerItemDecoration(this@CatalogActivity, DividerItemDecoration.VERTICAL))
+            addItemDecoration(
+                DividerItemDecoration(
+                    this@CatalogActivity,
+                    DividerItemDecoration.VERTICAL
+                )
+            )
             layoutAnimation = animation
         }
     }

--- a/app/src/main/java/com/chrisvasqm/cuadramo/editor/EditorActivity.kt
+++ b/app/src/main/java/com/chrisvasqm/cuadramo/editor/EditorActivity.kt
@@ -10,6 +10,7 @@ import android.widget.FrameLayout
 import androidx.appcompat.app.AppCompatActivity
 import com.chrisvasqm.cuadramo.R
 import com.chrisvasqm.cuadramo.data.models.Cuadre
+import com.chrisvasqm.cuadramo.databinding.ActivityEditorBinding
 import com.chrisvasqm.cuadramo.extensions.clear
 import com.chrisvasqm.cuadramo.extensions.toInt
 import com.chrisvasqm.cuadramo.ui.PreviewBottomSheetDialogFragment
@@ -20,6 +21,9 @@ import kotlinx.android.synthetic.main.activity_editor.*
 import kotlinx.android.synthetic.main.toolbar.*
 
 class EditorActivity : AppCompatActivity(), EditorContract.View {
+
+    private lateinit var binding: ActivityEditorBinding
+
     private val TAG = "EditorActivity"
 
     private lateinit var presenter: EditorContract.Presenter
@@ -39,7 +43,7 @@ class EditorActivity : AppCompatActivity(), EditorContract.View {
                     inputFreebies.text?.isNotBlank()!! ||
                     inputDelivery.text?.isNotBlank()!! ||
                     inputOthers.text?.isNotBlank()!!
-            btnClear.isEnabled = isAnyFieldFilled
+            binding.btnClear.isEnabled = isAnyFieldFilled
         }
     }
 
@@ -47,21 +51,24 @@ class EditorActivity : AppCompatActivity(), EditorContract.View {
         override fun afterTextChanged(s: Editable?) {}
         override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
         override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-            btnCuadrar.isEnabled = inputTicketsTotal.text.toInt() > inputTicketsLeft.text.toInt()
+            binding.btnCuadrar.isEnabled =
+                inputTicketsTotal.text.toInt() > inputTicketsLeft.text.toInt()
         }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_editor)
+        binding = ActivityEditorBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         setSupportActionBar(toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
         presenter = EditorPresenter().apply { attach(this@EditorActivity) }
         router = EditorRouter(this)
 
-        btnClear.setOnClickListener { presenter.clearForm() }
+        binding.btnClear.setOnClickListener { presenter.clearForm() }
 
-        btnCuadrar.setOnClickListener { presenter.showPreview() }
+        binding.btnCuadrar.setOnClickListener { presenter.showPreview() }
 
         setupClearButtonWatcher()
         setupCuadrarButtonWatcher()
@@ -73,30 +80,30 @@ class EditorActivity : AppCompatActivity(), EditorContract.View {
     }
 
     private fun setupClearButtonWatcher() {
-        inputCash.addTextChangedListener(clearWatcher)
-        inputTicketsTotal.addTextChangedListener(clearWatcher)
-        inputTicketsLeft.addTextChangedListener(clearWatcher)
-        inputFood.addTextChangedListener(clearWatcher)
-        inputFreebies.addTextChangedListener(clearWatcher)
-        inputDelivery.addTextChangedListener(clearWatcher)
-        inputOthers.addTextChangedListener(clearWatcher)
+        binding.inputCash.addTextChangedListener(clearWatcher)
+        binding.inputTicketsTotal.addTextChangedListener(clearWatcher)
+        binding.inputTicketsLeft.addTextChangedListener(clearWatcher)
+        binding.inputFood.addTextChangedListener(clearWatcher)
+        binding.inputFreebies.addTextChangedListener(clearWatcher)
+        binding.inputDelivery.addTextChangedListener(clearWatcher)
+        binding.inputOthers.addTextChangedListener(clearWatcher)
     }
 
     private fun setupCuadrarButtonWatcher() {
-        inputTicketsTotal.addTextChangedListener(cuadrarWatcher)
-        inputTicketsLeft.addTextChangedListener(cuadrarWatcher)
+        binding.inputTicketsTotal.addTextChangedListener(cuadrarWatcher)
+        binding.inputTicketsLeft.addTextChangedListener(cuadrarWatcher)
     }
 
     override fun getCuadre(): Cuadre {
         return Cuadre(
-                "",
-                inputCash.text.toInt(),
-                inputTicketsTotal.text.toInt(),
-                inputTicketsLeft.text.toInt(),
-                inputFood.text.toInt(),
-                inputFreebies.text.toInt(),
-                inputDelivery.text.toInt(),
-                inputOthers.text.toInt()
+            "",
+            inputCash.text.toInt(),
+            inputTicketsTotal.text.toInt(),
+            inputTicketsLeft.text.toInt(),
+            inputFood.text.toInt(),
+            inputFreebies.text.toInt(),
+            inputDelivery.text.toInt(),
+            inputOthers.text.toInt()
         )
     }
 
@@ -121,8 +128,8 @@ class EditorActivity : AppCompatActivity(), EditorContract.View {
 
     override fun showPreview() {
         PreviewBottomSheetDialogFragment()
-                .apply { setCuadre(getCuadre()) }
-                .show(supportFragmentManager, TAG)
+            .apply { setCuadre(getCuadre()) }
+            .show(supportFragmentManager, TAG)
     }
 
     override fun saveTemporaryCuadre() {
@@ -130,19 +137,23 @@ class EditorActivity : AppCompatActivity(), EditorContract.View {
     }
 
     override fun displayUndoMessage() {
-        Snackbar.make(editorCoordinatorLayout, getString(R.string.fields_cleared), Snackbar.LENGTH_LONG)
-                .setAction(getString(R.string.undo)) { restoreForm() }
-                .show()
+        Snackbar.make(
+            editorCoordinatorLayout,
+            getString(R.string.fields_cleared),
+            Snackbar.LENGTH_LONG
+        )
+            .setAction(getString(R.string.undo)) { restoreForm() }
+            .show()
     }
 
     override fun restoreForm() {
-        inputCash.setText(undoCuadre.cash.toString())
-        inputTicketsTotal.setText(undoCuadre.ticketsTotal.toString())
-        inputTicketsLeft.setText(undoCuadre.ticketsLeft.toString())
-        inputFood.setText(undoCuadre.food.toString())
-        inputFreebies.setText(undoCuadre.freebies.toString())
-        inputDelivery.setText(undoCuadre.delivery.toString())
-        inputOthers.setText(undoCuadre.extras.toString())
+        binding.inputCash.setText(undoCuadre.cash.toString())
+        binding.inputTicketsTotal.setText(undoCuadre.ticketsTotal.toString())
+        binding.inputTicketsLeft.setText(undoCuadre.ticketsLeft.toString())
+        binding.inputFood.setText(undoCuadre.food.toString())
+        binding.inputFreebies.setText(undoCuadre.freebies.toString())
+        binding.inputDelivery.setText(undoCuadre.delivery.toString())
+        binding.inputOthers.setText(undoCuadre.extras.toString())
     }
 
 }

--- a/app/src/main/java/com/chrisvasqm/cuadramo/signin/SignInActivity.kt
+++ b/app/src/main/java/com/chrisvasqm/cuadramo/signin/SignInActivity.kt
@@ -5,16 +5,18 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.chrisvasqm.cuadramo.R
 import com.chrisvasqm.cuadramo.catalog.CatalogActivity
+import com.chrisvasqm.cuadramo.databinding.ActivitySignInBinding
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.api.ApiException
 import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.auth.FirebaseUser
-import kotlinx.android.synthetic.main.activity_sign_in.*
 import timber.log.Timber
 
 class SignInActivity : AppCompatActivity(), SignInContract.View {
+
+    private lateinit var binding: ActivitySignInBinding
 
     private val TAG: String = this::class.java.simpleName
 
@@ -27,7 +29,8 @@ class SignInActivity : AppCompatActivity(), SignInContract.View {
     override fun onCreate(savedInstanceState: Bundle?) {
         setTheme(R.style.AppTheme)
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_sign_in)
+        binding = ActivitySignInBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         presenter = SignInPresenter().apply { attach(this@SignInActivity) }
 
         val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
@@ -37,7 +40,7 @@ class SignInActivity : AppCompatActivity(), SignInContract.View {
 
         client = GoogleSignIn.getClient(this, gso)
 
-        btnSignIn.setOnClickListener { presenter.signIn() }
+        binding.btnSignIn.setOnClickListener { presenter.signIn() }
     }
 
     override fun onDestroy() {
@@ -82,7 +85,7 @@ class SignInActivity : AppCompatActivity(), SignInContract.View {
     }
 
     override fun showMessage(message: String) {
-        Snackbar.make(signInLayout, message, Snackbar.LENGTH_SHORT).show()
+        Snackbar.make(binding.signInLayout, message, Snackbar.LENGTH_SHORT).show()
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -92,11 +95,11 @@ class SignInActivity : AppCompatActivity(), SignInContract.View {
             val task = GoogleSignIn.getSignedInAccountFromIntent(data)
 
             try {
-                val account = task?.getResult(ApiException::class.java)
+                val account = task.getResult(ApiException::class.java)
                 presenter.authWithGoogle(account)
             } catch (exception: ApiException) {
                 Timber.w(TAG, "Google Sign In failed: $exception")
-                Snackbar.make(signInLayout, "Google sign in failed.", Snackbar.LENGTH_LONG).show()
+                Snackbar.make(binding.signInLayout, "Google sign in failed.", Snackbar.LENGTH_LONG).show()
             }
         }
     }


### PR DESCRIPTION
Kotlin Synthetic binding methods are no longer recommended, we should be using Android Jetpack's [View Binding](https://developer.android.com/topic/libraries/view-binding)

Some of the benefits are:

1. Null safety
2. Type safety
3. Easier to use
4. Faster compilation 