### PR TITLE
Refactor UserRepository

### DIFF
--- a/app/src/main/java/com/chrisvasqm/cuadramo/data/source/user/UserDataSource.kt
+++ b/app/src/main/java/com/chrisvasqm/cuadramo/data/source/user/UserDataSource.kt
@@ -1,9 +1,0 @@
-package com.chrisvasqm.cuadramo.data.source.user
-
-import com.google.firebase.auth.FirebaseUser
-
-interface UserDataSource {
-
-    fun getCurrentUser(): FirebaseUser?
-
-}

--- a/app/src/main/java/com/chrisvasqm/cuadramo/data/source/user/UserService.kt
+++ b/app/src/main/java/com/chrisvasqm/cuadramo/data/source/user/UserService.kt
@@ -3,9 +3,9 @@ package com.chrisvasqm.cuadramo.data.source.user
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 
-object UserRepository : UserDataSource {
+class UserService {
 
-    override fun getCurrentUser(): FirebaseUser? {
+    fun getCurrentUser(): FirebaseUser? {
         return FirebaseAuth.getInstance().currentUser
     }
 

--- a/app/src/main/java/com/chrisvasqm/cuadramo/signin/SignInPresenter.kt
+++ b/app/src/main/java/com/chrisvasqm/cuadramo/signin/SignInPresenter.kt
@@ -1,6 +1,6 @@
 package com.chrisvasqm.cuadramo.signin
 
-import com.chrisvasqm.cuadramo.data.source.user.UserRepository
+import com.chrisvasqm.cuadramo.data.source.user.UserService
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
@@ -11,7 +11,7 @@ class SignInPresenter : SignInContract.Presenter {
 
     private val auth = FirebaseAuth.getInstance()
 
-    private val repository = UserRepository
+    private val service = UserService()
 
     override fun attach(view: SignInContract.View) {
         this.view = view
@@ -26,7 +26,7 @@ class SignInPresenter : SignInContract.Presenter {
     }
 
     override fun updateUi() {
-        view?.updateUi(repository.getCurrentUser())
+        view?.updateUi(service.getCurrentUser())
     }
 
     override fun authWithGoogle(account: GoogleSignInAccount?) {


### PR DESCRIPTION
## Summary

The `UserRepository` only has a single method that is used to retrieve the current logged-in `FirebaseUser`, but that was a misuse of the [Repository Pattern](https://www.martinfowler.com/eaaCatalog/repository.html).

### Changelog

1. Removed the `UserDataSource` interface from the project.
2. Renamed the `UserRepository` -> `UserService`.
3. Changed the `UserService` from being a [Singleton](https://en.wikipedia.org/wiki/Singleton_pattern) to a regular `class`.